### PR TITLE
Adding ability to target specific application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 HotKeys
 =====
 
-A simple gem which allows you to bind global hot keys with macruby
+A simple gem which allows you to bind global hot keys with macruby, optionally can also specify
+which application needs to be frontmost (inspired by Keyboard Maestro)
 
 1. `gem install hotkeys`
 2. `macruby examples/simple.rb`
@@ -16,7 +17,9 @@ Usage example:
       def applicationDidFinishLaunching(notification)
         @hotkeys = HotKeys.new
 
-        @hotkeys.addHotString("R+COMMAND") do
+        # Will only trigger if iTerm2 is frontmost application, second option can be left blank
+        # for truly global shortcut
+        @hotkeys.addHotString("Space+OPTION","com.googlecode.iterm2") do
           puts "LOL MACRUBY RUNS"
         end
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Usage example:
       def applicationDidFinishLaunching(notification)
         @hotkeys = HotKeys.new
 
-        # Will only trigger if iTerm2 is frontmost application, second option can be left blank
+        # Will only trigger if Safari is frontmost application, second option can be left blank
         # for truly global shortcut
-        @hotkeys.addHotString("Space+OPTION","com.googlecode.iterm2") do
+        @hotkeys.addHotString("Space+OPTION","com.apple.safari") do
           puts "LOL MACRUBY RUNS"
         end
 

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -5,7 +5,7 @@ require 'hotkeys'
 def applicationDidFinishLaunching(notification)
   @hotkeys = HotKeys.new
 
-  # Will only trigger if iTerm2 is frontmost application, second option can be left blank
+  # Will only trigger if Safari is frontmost application, second option can be left blank
   # for truly global shortcut
   @hotkeys.addHotString("Space+OPTION","com.apple.safari") do
     puts "LOL MACRUBY RUNS"

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -5,7 +5,9 @@ require 'hotkeys'
 def applicationDidFinishLaunching(notification)
   @hotkeys = HotKeys.new
 
-  @hotkeys.addHotString("Space+OPTION") do
+  # Will only trigger if iTerm2 is frontmost application, second option can be left blank
+  # for truly global shortcut
+  @hotkeys.addHotString("Space+OPTION","com.googlecode.iterm2") do
     puts "LOL MACRUBY RUNS"
   end
 

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -7,7 +7,7 @@ def applicationDidFinishLaunching(notification)
 
   # Will only trigger if iTerm2 is frontmost application, second option can be left blank
   # for truly global shortcut
-  @hotkeys.addHotString("Space+OPTION","com.googlecode.iterm2") do
+  @hotkeys.addHotString("Space+OPTION","com.apple.safari") do
     puts "LOL MACRUBY RUNS"
   end
 


### PR DESCRIPTION
I am aiming to use Hotkeys to replace Keyboard Maestro for a project where I use AppleScript + Ruby as a glue between different application. I need the ability to target specific applications, so I added this to Hotkeys. The new format for addHotString is 

```
    @hotkeys.addHotString("Space+OPTION","com.googlecode.iterm2") do
      puts "LOL MACRUBY RUNS"
    end
```

where the second string is the bundleIdentifier, which is optional (default is targetting all applications).

Uses System Events and ScriptingBridge to get frontmost application.
